### PR TITLE
최근읽은포스트 중복처리, 메인페이지 무한스크롤 연결

### DIFF
--- a/src/components/Details/DetailHeader.tsx
+++ b/src/components/Details/DetailHeader.tsx
@@ -1,12 +1,12 @@
-import styled from "@emotion/styled";
-import { UDHashContainer } from "./UDHashContainer";
-import { SeriesContainer } from "./SeriesContainer";
-import { Intro } from "../MyPage";
-import { Carousel } from "./Carousel";
-import { Comment } from "./Comment";
-import useIO from "../../hooks/useIO";
-import { API_ENDPOINT } from "../../constants";
-import axios, { Method } from "axios";
+import styled from '@emotion/styled';
+import { UDHashContainer } from './UDHashContainer';
+import { SeriesContainer } from './SeriesContainer';
+import { Intro } from '../MyPage';
+import { Carousel } from './Carousel';
+import { Comment } from './Comment';
+import useIO from '../../hooks/useIO';
+import { API_ENDPOINT } from '../../constants';
+import axios, { Method } from 'axios';
 
 
 interface DetailData {

--- a/src/components/Home/Filter.tsx
+++ b/src/components/Home/Filter.tsx
@@ -1,14 +1,15 @@
-import Link from "next/link";
-import React from "react";
-import styled from "@emotion/styled";
-import { Notice, SelectBox } from "./index";
-import { MEDIA_QUERY_END_POINT, PALLETS_LIGHT } from "../../constants";
-import MovingIcon from "@mui/icons-material/Moving";
-import AccessTimeIcon from "@mui/icons-material/AccessTime";
-import { Theme } from "../../styles/theme";
-import { useState, useContext, useEffect } from "react";
-import { ThemeContext } from "../../pages/_app";
-import { CardContainer } from "../Home/CardContainer";
+import Link from 'next/link';
+import React from 'react';
+import styled from '@emotion/styled';
+import { Notice, SelectBox } from './index';
+import { MEDIA_QUERY_END_POINT, PALLETS_LIGHT } from '../../constants';
+import MovingIcon from '@mui/icons-material/Moving';
+import AccessTimeIcon from '@mui/icons-material/AccessTime';
+import { Theme } from '../../styles/theme';
+import { useState, useContext, useEffect } from 'react';
+import { ThemeContext } from '../../pages/_app';
+import { CardContainer } from '../Home/CardContainer';
+import { IOCardContainer } from '../Home/IOCardContainer';
 
 interface StyledType {
   theme: Theme;
@@ -19,7 +20,7 @@ export const Filter = ({ route }: { route: string }) => {
   const { theme } = useContext(ThemeContext);
 
   const [filteredText, setFilteredText] = useState(
-    route === "home" ? "이번 주" : "최신"
+    route === 'home' ? '이번 주' : '최신'
   );
 
   function handleClick(e: string) {
@@ -33,30 +34,30 @@ export const Filter = ({ route }: { route: string }) => {
           <BoxContainer>
             <Link
               href={
-                route === "recent" || route === "home" ? "/" : "/list/liked"
+                route === 'recent' || route === 'home' ? '/' : '/list/liked'
               }
               passHref
             >
               <FilterName theme={theme} route={route}>
                 <TrendIcon route={route} />
-                {route === "recent" || route === "home"
-                  ? "트렌딩"
-                  : "좋아요한 포스트"}
+                {route === 'recent' || route === 'home'
+                  ? '트렌딩'
+                  : '좋아요한 포스트'}
               </FilterName>
             </Link>
             <Link
               href={
-                route === "recent" || route === "home"
-                  ? "/recent"
-                  : "/list/read"
+                route === 'recent' || route === 'home'
+                  ? '/recent'
+                  : '/list/read'
               }
               passHref
             >
               <FilterName theme={theme} route={route}>
                 <ClockIcon route={route} />
-                {route === "recent" || route === "home"
-                  ? "최신"
-                  : "최근 읽은 포스트"}
+                {route === 'recent' || route === 'home'
+                  ? '최신'
+                  : '최근 읽은 포스트'}
               </FilterName>
             </Link>
             <Line theme={theme} route={route}></Line>
@@ -65,25 +66,26 @@ export const Filter = ({ route }: { route: string }) => {
         </BoxContainer>
         <Notice route={route}></Notice>
       </FilterContainer>
-      <CardContainer filter={filteredText}></CardContainer>
+      {/* <CardContainer filter={filteredText}></CardContainer> */}
+      <IOCardContainer filter={filteredText}></IOCardContainer>
     </>
   );
 };
 
 const TrendIcon = styled(MovingIcon)<{ route: string }>`
   display: ${(props) =>
-    props.route === "home" || props.route === "recent"
-      ? "inline-block"
-      : "none"};
+    props.route === 'home' || props.route === 'recent'
+      ? 'inline-block'
+      : 'none'};
   @media (max-width: ${MEDIA_QUERY_END_POINT.TABLET}) {
     font-size: 20px;
   }
 `;
 const ClockIcon = styled(AccessTimeIcon)<{ route: string }>`
   display: ${(props) =>
-    props.route === "home" || props.route === "recent"
-      ? "inline-block"
-      : "none"};
+    props.route === 'home' || props.route === 'recent'
+      ? 'inline-block'
+      : 'none'};
   @media (max-width: ${MEDIA_QUERY_END_POINT.TABLET}) {
     font-size: 20px;
   }
@@ -91,34 +93,34 @@ const ClockIcon = styled(AccessTimeIcon)<{ route: string }>`
 const FilterName = styled.a<StyledType>`
   font-weight: bold;
   width: ${(props) =>
-    props.route === "home" || props.route === "recent" ? "80px" : "144px"};
+    props.route === 'home' || props.route === 'recent' ? '80px' : '144px'};
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 16px;
   text-decoration: none;
   color: ${(props) =>
-    props.route === "home" || props.route === "liked"
+    props.route === 'home' || props.route === 'liked'
       ? props.theme.MAIN_FONT
       : props.theme.POINT_FONT};
   height: 48px;
   & + & {
     color: ${(props) =>
-      props.route === "home" || props.route === "liked"
+      props.route === 'home' || props.route === 'liked'
         ? props.theme.POINT_FONT
         : props.theme.MAIN_FONT};
   }
   @media (min-width: 1024px) {
     font-size: 18px;
     width: ${(props) =>
-      props.route === "home" || props.route === "recent" ? "112px" : "144px"};
+      props.route === 'home' || props.route === 'recent' ? '112px' : '144px'};
   }
 `;
 
 const Line = styled.div<StyledType>`
   width: 50%;
   left: ${(props) =>
-    props.route === "home" || props.route === "liked" ? "0%" : "50%"};
+    props.route === 'home' || props.route === 'liked' ? '0%' : '50%'};
   height: 2px;
   position: absolute;
   bottom: 0px;

--- a/src/components/Home/IOCardContainer.tsx
+++ b/src/components/Home/IOCardContainer.tsx
@@ -10,6 +10,24 @@ import { MEDIA_QUERY_END_POINT } from '../../constants';
 let PAGE_SIZE = 3;
 
 export const IOCardContainer = ({ filter }: { filter: string }) => {
+  useEffect(() => {
+    PAGE_SIZE = window.matchMedia(
+      `(min-width: ${MEDIA_QUERY_END_POINT.XLARGE})`
+    ).matches
+      ? 5
+      : window.matchMedia(`(min-width: ${MEDIA_QUERY_END_POINT.LARGE})`).matches
+      ? 4
+      : window.matchMedia(`(min-width: ${MEDIA_QUERY_END_POINT.TABLET})`)
+          .matches
+      ? 3
+      : window.matchMedia(`(min-width: ${MEDIA_QUERY_END_POINT.MOBILE})`)
+          .matches
+      ? 2
+      : 1;
+    console.log(`window.innerWidth, ${window.innerWidth}`);
+    console.log(`PAGE_SIZE ${PAGE_SIZE}`);
+  }, []);
+
   const getKey = (pageIndex: number, previousPageData: any) => {
     if (previousPageData && !previousPageData.data) return null;
     const query = qs.stringify(

--- a/src/components/Home/IOCardContainer.tsx
+++ b/src/components/Home/IOCardContainer.tsx
@@ -1,0 +1,122 @@
+import { fetcher } from '../../utils/fetcher';
+import useSWRInfinite from 'swr/infinite';
+import { API_ENDPOINT } from '../../constants';
+import { useEffect, useRef, useState } from 'react';
+import styled from '@emotion/styled';
+import qs from 'qs';
+import { PostCard } from '.';
+import { MEDIA_QUERY_END_POINT } from '../../constants';
+
+let PAGE_SIZE = 3;
+
+export const IOCardContainer = ({ filter }: { filter: string }) => {
+  const getKey = (pageIndex: number, previousPageData: any) => {
+    if (previousPageData && !previousPageData.data) return null;
+    const query = qs.stringify(
+      {
+        pagination: {
+          page: pageIndex,
+          pageSize: PAGE_SIZE,
+        },
+        populate: ['*'],
+        sort: ['publishedAt'],
+      },
+      {
+        encodeValuesOnly: true,
+      }
+    );
+    return `${API_ENDPOINT}/posts?${query}`;
+  };
+
+  const { data, size, setSize, error, isValidating } = useSWRInfinite(
+    getKey,
+    fetcher
+  );
+
+  const isEmpty = data?.[0]?.length === 0;
+  const isReachingEnd = useRef<boolean>(false);
+
+  const [target, setTarget] = useState<HTMLElement | null | undefined>(null);
+
+  useEffect(() => {
+    if (size == 1) isReachingEnd.current = false;
+    if (!target || isReachingEnd.current) return;
+    const observer = new IntersectionObserver(onIntersect, {
+      threshold: 0.4,
+    });
+    observer.observe(target);
+    return () => observer && observer.disconnect();
+  }, [data, target]);
+
+  const onIntersect: IntersectionObserverCallback = ([entry], observer) => {
+    if (entry.isIntersecting) {
+      setSize((prev) => prev + 1);
+      isReachingEnd.current =
+        data === undefined
+          ? false
+          : isEmpty || (data && data[data.length - 1]?.data.length < PAGE_SIZE);
+    }
+  };
+
+  return (
+    <>
+      <Container>
+        {data &&
+          data
+            .filter((e, i) => {
+              if (size == 1) return true;
+              else {
+                return i !== 0;
+              }
+            })
+            .map((loaded) => {
+              return loaded.data.map((e: any, i: number) => (
+                <PostCard
+                  key={`${e}_${i}`}
+                  imageUrl={e.attributes.imageUrl}
+                  title={e.attributes.title}
+                  contents={e.attributes.contents}
+                  comments={e.attributes.comments}
+                  username={'deli-ght'}
+                  count={e.attributes.count}
+                  publishedAt={e.attributes.publishedAt}
+                />
+              ));
+            })}
+      </Container>
+      <TargetElement ref={setTarget}>
+        {isValidating && !isReachingEnd.current && <div>로딩중</div>}
+      </TargetElement>
+    </>
+  );
+};
+const Container = styled.section`
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: 16px;
+  margin: 0 auto;
+  @media (min-width: ${MEDIA_QUERY_END_POINT.MOBILE}) {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 32px;
+  }
+  @media (min-width: ${MEDIA_QUERY_END_POINT.TABLET}) {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 32px;
+    max-width: ${MEDIA_QUERY_END_POINT.TABLET};
+  }
+  @media (min-width: ${MEDIA_QUERY_END_POINT.LARGE}) {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px;
+    max-width: ${MEDIA_QUERY_END_POINT.LARGE};
+  }
+  @media (min-width: ${MEDIA_QUERY_END_POINT.XLARGE}) {
+    grid-template-columns: repeat(5, 1fr);
+    gap: 32px;
+    max-width: 1728px;
+  }
+`;
+
+const TargetElement = styled.article`
+  width: 100%;
+  height: 100px;
+`;

--- a/src/hooks/useIO.tsx
+++ b/src/hooks/useIO.tsx
@@ -8,9 +8,6 @@ interface useIntersectionObserverProps {
 }
 
 const useIntersectionObserver = ({
-  // root = null,
-  // rootMargin = '0px',
-  // threshold = 0.5,
   root,
   rootMargin,
   threshold,
@@ -26,11 +23,10 @@ const useIntersectionObserver = ({
       { root, rootMargin, threshold }
     );
     observer.observe(target);
-
     // return () => observer.unobserve(target);
     return () => observer && observer.disconnect();
-  }, [onIntersect, root, rootMargin, target, threshold]);
-
+  }, [target]);
+  // [onIntersect, root, rootMargin, target, threshold]
   return { setTarget };
 };
 

--- a/src/pages/[id]/[details]/index.tsx
+++ b/src/pages/[id]/[details]/index.tsx
@@ -1,20 +1,20 @@
-import { NextPage } from "next";
-import styled from "@emotion/styled";
-import Head from "next/head";
+import { NextPage } from 'next';
+import styled from '@emotion/styled';
+import Head from 'next/head';
 
-import { DetailHeader } from "../../../components/Details/DetailHeader";
-import { LeftHeader } from "../../../components/Details/LeftHeader";
-import { RightHeader } from "../../../components/Details/RightHeader";
+import { DetailHeader } from '../../../components/Details/DetailHeader';
+import { LeftHeader } from '../../../components/Details/LeftHeader';
+import { RightHeader } from '../../../components/Details/RightHeader';
 
 // import { CardContainer } from "../../../components/Home/CardContainer";
-import { Header } from "../../../components/Common/Header";
+import { Header } from '../../../components/Common/Header';
 
-import { Theme } from "../../../styles/theme";
-import { useContext } from "react";
-import { ThemeContext } from "../../_app";
-import { useRouter } from "next/router";
-import { useData } from "../../../hooks/useData";
-import { ErrorPage } from "../../../components/Details/ErrorPage";
+import { Theme } from '../../../styles/theme';
+import { useContext } from 'react';
+import { ThemeContext } from '../../_app';
+import { useRouter } from 'next/router';
+import { useData } from '../../../hooks/useData';
+import { ErrorPage } from '../../../components/Details/ErrorPage';
 
 interface ThemeProps {
   theme: Theme;
@@ -90,28 +90,17 @@ const DetailsIndexPage: NextPage = () => {
   let postid = 0;
 
   let postObj = {
-    title: "",
-    contents: "",
-    url: "",
+    title: '',
+    contents: '',
+    url: '',
     likeposts: {
       data: [],
     },
     comments: {
       data: [],
     },
-    createdAt: "",
+    createdAt: '',
   };
-
-  const { data: DetailData, error: DetailError } = useData(
-    "posts",
-    "populate=*"
-  );
-
-  if (!DetailData) return <div>로딩중</div>;
-  if (DetailError) return <div>에러</div>;
-
-  let postid = 0;
-
 
   DetailData.data.some((details: Post) => {
     if (
@@ -133,7 +122,7 @@ const DetailsIndexPage: NextPage = () => {
       </Head>
       {postObj.title ? (
         <div>
-          <Header username={"deli-ght"} user={true} />
+          <Header username={'deli-ght'} user={true} />
           <DetailContainer>
             <LeftHeader likepost={postObj.likeposts.data} />
             <DetailHeader

--- a/src/pages/[id]/[details]/index.tsx
+++ b/src/pages/[id]/[details]/index.tsx
@@ -62,11 +62,32 @@ interface Post {
   };
 }
 
+interface ReadingPost {
+  id: number;
+  attributes: {
+    postid: {
+      data: {
+        id: number;
+      };
+    };
+  };
+}
+
 const DetailsIndexPage: NextPage = () => {
   const { theme } = useContext(ThemeContext);
   const router = useRouter();
   const userName = router.query.id;
   const userDetails = router.query.details;
+
+  const { data: DetailData, error: DetailError } = useData(
+    'posts',
+    'populate=*'
+  );
+
+  if (!DetailData) return <div>로딩중</div>;
+  if (DetailError) return <div>에러</div>;
+
+  let postid = 0;
 
   let postObj = {
     title: '',
@@ -79,15 +100,6 @@ const DetailsIndexPage: NextPage = () => {
       data: [],
     },
   };
-  const { data: DetailData, error: DetailError } = useData(
-    'posts',
-    'populate=*'
-  );
-
-  if (!DetailData) return <div>로딩중</div>;
-  if (DetailError) return <div>에러</div>;
-
-  let postid = 0;
 
   DetailData.data.some((details: Post) => {
     if (


### PR DESCRIPTION
## 세부 사항
- 최근 읽은 포스트 중복처리
- mainpage 무한스크롤 연결
- pagesize 미디어쿼리추가

## 기타 질문 및 특이 사항
- 🐛  데이터 불러오는 중에도 뷰포트가 변경되면 pagesize를 바꾸고 싶은데, 의존성배열에 window를 넣을 수 없음
-  🐛  현재 post데이터에 작성자가 없는 데이터들이 있어서, 임의로 username 넣어놓음
-  최근/트렌딩 순 필터링 다시 구현해야함 - 무한스크롤 연결
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
