### PR TITLE
🐛 로그아웃 시 읽기목록 및 좋아요 에러 처리

### DIFF
--- a/src/components/Details/DetailHeader.tsx
+++ b/src/components/Details/DetailHeader.tsx
@@ -33,6 +33,8 @@ interface DetailData {
   comments: Comments[];
   userdata: userInfo;
   hashtags: Hashtags[];
+  loginUserId: number | undefined;
+  loginUserName: string | string[] | undefined;
 }
 
 interface ReadingPost {
@@ -55,12 +57,14 @@ export const DetailHeader = ({
   createdAt,
   userdata,
   hashtags,
+  loginUserId,
+  loginUserName,
 }: DetailData) => {
-  const getReadingData = async (userName: string) => {
+  const getReadingData = async () => {
     let putId = 0;
     const response = await axios({
       method: "get",
-      url: `${API_ENDPOINT}/readingposts?populate=*&filters[userid][profilename]=${userName}`,
+      url: `${API_ENDPOINT}/readingposts?populate=*&filters[userid][userid]=${loginUserName}`,
     });
     const handleOverlap = response.data.data.some((post: ReadingPost) => {
       if (post.attributes.postid.data.id === postid) {
@@ -79,7 +83,7 @@ export const DetailHeader = ({
       url: `${API_ENDPOINT}/readingposts/${putid}`,
       data: {
         data: {
-          userid: 163,
+          userid: loginUserId,
           postid: postid,
         },
       },
@@ -97,7 +101,7 @@ export const DetailHeader = ({
   ) => {
     if (entry.isIntersecting) {
       observer.unobserve(entry.target);
-      getReadingData("ong");
+      loginUserId && getReadingData();
     }
   };
 
@@ -118,7 +122,7 @@ export const DetailHeader = ({
       />
       <SeriesContainer />
       <div>{contents}</div>
-      {/* <div ref={setTarget}></div> */}
+      <div ref={setTarget}></div>
       <Intro username={userName} userdata={userdata} />
       <Carousel />
       <CommentFormContainer comments={comments} />

--- a/src/components/Details/LeftHeader.tsx
+++ b/src/components/Details/LeftHeader.tsx
@@ -14,11 +14,8 @@ import { useContext } from "react";
 import { ThemeContext } from "../../pages/_app";
 import axios, { Method } from "axios";
 
-import Cookies from "js-cookie";
 import { handleDate } from "../../utils/date";
-
-// import useSWR from "swr";
-// import axios from "axios";
+import { breakpoints } from "@mui/system";
 
 interface ThemeProps {
   theme: Theme;
@@ -27,6 +24,8 @@ interface ThemeProps {
 interface LikePost {
   likepost: never[];
   postid: number;
+  loginUserId: number | undefined;
+  loginUserName: string | string[] | undefined;
 }
 
 interface ILikePost {
@@ -41,23 +40,21 @@ interface ILikePost {
     };
   };
 }
-export const LeftHeader = ({ likepost, postid }: LikePost) => {
+export const LeftHeader = ({
+  likepost,
+  postid,
+  loginUserId,
+  loginUserName,
+}: LikePost) => {
   const { theme } = useContext(ThemeContext);
   const [heartNum, setHeartNum] = useState(likepost.length);
   const [heartClick, setHeartClick] = useState(false);
   const [shareClick, setShareClick] = useState(false);
   const [putId, setPutId] = useState(0);
 
-  const userCookieData = Cookies.get("user");
-
-  // 에러 처리
   useEffect(() => {
-    getLikeData();
+    loginUserId && getLikeData();
   }, []);
-
-  if (!userCookieData) return <h1>로딩중</h1>;
-  const userId: number = JSON.parse(userCookieData).id;
-  const userName: string = JSON.parse(userCookieData).attributes.userid;
 
   // const fetcher = (url: string) =>
   //   axios.put(url).then((res) => console.log(res.data));
@@ -69,6 +66,11 @@ export const LeftHeader = ({ likepost, postid }: LikePost) => {
   // console.log(data, "sdfsdf");
 
   const handleHeart = () => {
+    if (!loginUserId) {
+      alert("로그인이 필요합니다.");
+      return;
+    }
+
     let num = heartNum;
 
     setHeartClick(!heartClick);
@@ -84,7 +86,7 @@ export const LeftHeader = ({ likepost, postid }: LikePost) => {
   const getLikeData = async () => {
     const response = await axios({
       method: "get",
-      url: `${API_ENDPOINT}/likeposts?populate=*&filters[userid][userid]=${userName}`,
+      url: `${API_ENDPOINT}/likeposts?populate=*&filters[userid][userid]=${loginUserName}`,
     });
     const handleOverlap = response.data.data.some((post: ILikePost) => {
       if (post.attributes.postid.data[0].id === postid) {
@@ -101,7 +103,7 @@ export const LeftHeader = ({ likepost, postid }: LikePost) => {
       url: `${API_ENDPOINT}/likeposts`,
       data: {
         data: {
-          userid: userId,
+          userid: loginUserId,
           postid: postid,
         },
       },
@@ -117,7 +119,7 @@ export const LeftHeader = ({ likepost, postid }: LikePost) => {
       url: `${API_ENDPOINT}/likeposts/${putId}`,
       data: {
         data: {
-          userid: userId,
+          userid: loginUserId,
           postid: postid,
         },
       },

--- a/src/pages/[id]/[details]/index.tsx
+++ b/src/pages/[id]/[details]/index.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/router";
 import { useData } from "../../../hooks/useData";
 import { ErrorPage } from "../../../components/Common/ErrorPage";
 import { userInfo } from "../../../types/Main";
+import Cookies from "js-cookie";
 
 interface ThemeProps {
   theme: Theme;
@@ -96,21 +97,20 @@ const DetailsIndexPage: NextPage = () => {
     "populate=*"
   );
 
-  const { data: SeriesBoxData, error: SeriesBoxError } = useData(
-    "series-boxes",
-    ""
-  );
+  const { data: SeriesBoxData, error: SeriesBoxError } =
+    useData("series-boxes");
 
-  const { data: SeriesPostData, error: SeriesPostError } = useData(
-    "series-posts",
-    ""
-  );
+  const { data: SeriesPostData, error: SeriesPostError } =
+    useData("series-posts");
 
-  if (!DetailData || !SeriesBoxData || !SeriesPostData)
-    return <div>로딩중</div>;
-  if (DetailError || SeriesBoxError || SeriesPostError) return <div>에러</div>;
+  if (!DetailData) return <div>로딩중</div>;
+  if (DetailError) return <div>에러</div>;
 
-  // console.log(SeriesBoxData);
+  const userCookieData = Cookies.get("user");
+
+  const loginUserId = userCookieData && JSON.parse(userCookieData!).id;
+  const loginUserName =
+    userCookieData && JSON.parse(userCookieData!).attributes.userid;
 
   let postid = 0;
   let postObj = {
@@ -198,7 +198,12 @@ const DetailsIndexPage: NextPage = () => {
         <div>
           <Header username={"deli-ght"} user={true} />
           <DetailContainer>
-            <LeftHeader likepost={postObj.likeposts.data} postid={postid} />
+            <LeftHeader
+              likepost={postObj.likeposts.data}
+              postid={postid}
+              loginUserId={loginUserId}
+              loginUserName={loginUserName}
+            />
             <DetailHeader
               title={postObj.title}
               contents={postObj.contents}
@@ -208,6 +213,8 @@ const DetailsIndexPage: NextPage = () => {
               createdAt={postObj.createdAt}
               userdata={user}
               hashtags={postObj.hashtags.data}
+              loginUserId={loginUserId}
+              loginUserName={loginUserName}
             />
             <RightHeader />
           </DetailContainer>


### PR DESCRIPTION
## 세부 사항
- pages/[id]/[detail]/index.ts에서 각각 detailheader, leftheader에 cookie 내려주는 것으로 수정
- 로그아웃 시 읽기목록 및 좋아요 에러 처리

## 기타 질문 및 특이 사항
- 로그아웃 시 좋아요 클릭했을 때 임시로 alert 처리했는 데 UI 필요합니다.
- 좋아요/좋아요 취소 엄청 빨리 반복하면 에러 발생합니다.
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
